### PR TITLE
Inverted keys

### DIFF
--- a/src/Data/Table.hs
+++ b/src/Data/Table.hs
@@ -56,7 +56,7 @@ module Data.Table
   , autoIncrement
   -- * Implementation Details
   , IsKeyType(..)
-  , KeyType(..), Primary, Candidate, Supplemental
+  , KeyType(..), Primary, Candidate, Supplemental, Inverted
   , Index(..)
   ) where
 


### PR DESCRIPTION
Added Inverted keys and made them work. This involved adding the type KeyResult k a to the IsKey class, which for the older keys is just a, but for Inverted is [a]. This is so Inverted could fetch multiple results.
