### PR TITLE
Inverted keys use sets

### DIFF
--- a/src/Data/Table.hs
+++ b/src/Data/Table.hs
@@ -60,9 +60,9 @@ module Data.Table
   , IsKeyType(..)
   , KeyType(..)
   , Primary
-  , Candidate, CandidateInt
-  , Supplemental, SupplementalInt
-  , Inverted, InvertedInt
+  , Candidate, CandidateInt, CandidateHash
+  , Supplemental, SupplementalInt, SupplementalHash
+  , Inverted, InvertedInt, InvertedHash
   , Index(..)
   ) where
 


### PR DESCRIPTION
- Inverted keys use Sets
- InvertedInt keys use IntSets
- InvertedHash keys use HashSets
- Slight rearrangement of the Withal class to accommodate this
- Docs for the Table type now mentions key types other than the original three
- Hash-based keys are now exported
