### PR TITLE
Widen the bounds for 'binary'.

### DIFF
--- a/tables.cabal
+++ b/tables.cabal
@@ -44,7 +44,7 @@ flag transformers2
 library
   build-depends:
     base                 >= 4.3 && < 5,
-    binary               >= 0.5 && < 0.6,
+    binary               >= 0.5 && < 0.8,
     cereal               >= 0.3 && < 0.4,
     comonad              >= 4   && < 5,
     containers           >= 0.4 && < 0.6,


### PR DESCRIPTION
This fixes #18.

I'm not sure if there's a reason for the lower bound (other than "0.5 was the newest at the time") and @ekmett is not on irc, so I thought it would be better to pull request this for now. It seems like everything works fine with 'binary' 0.7.1.0.
