### PR TITLE
widened cereal version range.

### DIFF
--- a/tables.cabal
+++ b/tables.cabal
@@ -48,7 +48,7 @@ library
   build-depends:
     base                 >= 4.3 && < 5,
     binary               >= 0.5 && < 0.8,
-    cereal               >= 0.3 && < 0.4,
+    cereal               >= 0.3 && < 0.5,
     comonad              >= 4   && < 5,
     containers           >= 0.4 && < 0.6,
     deepseq              >= 1.3 && < 1.4,


### PR DESCRIPTION
cereal < 0.4 was starting to cause dependency hell, and widening it seemed to go ok.
